### PR TITLE
Add commands to the main menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": ">=0.17.0 <0.20.0",
+    "@jupyterlab/mainmenu": ">=0.8.0 < 0.9.0",
     "@jupyterlab/notebook": ">=0.17.0 <0.20.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Really cool project!

It can be useful to have the commands available in the main menu too.
For now they are under "Edit" but could belong to their own entry if that makes sense.

![image](https://user-images.githubusercontent.com/591645/49320543-6e0ebf00-f502-11e8-83b3-3105f8563e2e.png)
