### PR TITLE
Add autopep8 options to Advanced Settings Editor

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -52,7 +52,7 @@ class Autopep8Formatter(BaseFormatter):
     def format_code(self, code: str, **options) -> str:
         from autopep8 import fix_code
 
-        return fix_code(code, **options)
+        return fix_code(code, options=options)
 
 
 class YapfFormatter(BaseFormatter):

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -29,7 +29,29 @@
             "type": "object"
         },
         "autopep8": {
-            "properties": {},
+            "properties": {
+		"aggressive": {
+		    "type": "number"
+		},
+		"max_line_length": {
+		    "type": "number"
+		},
+		"ignore": {
+		    "type": "array",
+		    "items": {
+			"type": "string"
+		    }
+		},
+		"select": {
+		    "type": "array",
+		    "items": {
+			"type": "string"
+		    }
+		},
+		"experimental": {
+		    "type": "boolean"
+		}
+	    },
             "additionalProperties": false,
             "type": "object"
         }
@@ -53,7 +75,7 @@
         },
         "autopep8": {
             "title": "Autopep8 Config",
-            "description": "Config to be passed into autopep8's fix_code function call. Personally I don't use this, PR welcomed to fix this.",
+            "description": "Config to be passed into autopep8's fix_code function call as the options dictionary.",
             "$ref": "#/definitions/autopep8",
             "default": {}
         }


### PR DESCRIPTION
Black threw me an error that I couldn't trace back, so I went for autopep8. I wanted aggressive=2 though, so I added that in this pull request.
I added the most common options, there may be some more possible which I didn't check.