### PR TITLE
Enable custom style string for yapf

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -115,13 +115,7 @@
         "yapf": {
             "properties": {
                 "style_config": {
-                    "type": "string",
-                    "enum": [
-                        "pep8",
-                        "chromium",
-                        "google",
-                        "facebook"
-                    ]
+                    "type": "string"
                 }
             },
             "additionalProperties": false,


### PR DESCRIPTION
Yapf supports custom formatting options in the style_config. See https://github.com/ryantam626/jupyterlab_code_formatter/issues/38 for details

Closes #38