### PR TITLE
Retain semicolon after black formatting

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -34,7 +34,9 @@ class BlackFormatter(BaseFormatter):
     def format_code(self, code: str, **options) -> str:
         import black
 
-        code = re.sub("^%", "#%#", code, flags=re.M)
+        has_semicolon = code.strip().endswith(";")
+        
+        code = re.sub("^%", "#%#", original_code, flags=re.M)
 
         if black.__version__ >= '19.3b0':
             code = black.format_str(code, mode=black.FileMode(**options))[:-1]
@@ -43,6 +45,9 @@ class BlackFormatter(BaseFormatter):
 
         code = re.sub("^#%#", "%", code, flags=re.M)
 
+        if has_semicolon:
+            code += ";"
+        
         return code
 
 

--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -36,7 +36,7 @@ class BlackFormatter(BaseFormatter):
 
         has_semicolon = code.strip().endswith(";")
         
-        code = re.sub("^%", "#%#", original_code, flags=re.M)
+        code = re.sub("^%", "#%#", code, flags=re.M)
 
         if black.__version__ >= '19.3b0':
             code = black.format_str(code, mode=black.FileMode(**options))[:-1]


### PR DESCRIPTION
Thanks for this awesome project!

It is often useful to allow the final line of a cell to end with a semicolon so that the output is not printed, but black removes all semicolons. This suggested patch will retain a single trailing semicolon if it exists.