### PR TITLE
Remove new line at the end of YAPF formatting

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -86,7 +86,7 @@ class YapfFormatter(BaseFormatter):
     def format_code(self, code: str, **options) -> str:
         from yapf.yapflib.yapf_api import FormatCode
 
-        return FormatCode(code, **options)[0]
+        return FormatCode(code, **options)[0][:-1]
 
 
 class IsortFormatter(BaseFormatter):


### PR DESCRIPTION
YAPF adds a new line at the end of each cell, this gets rid of it. Similar to what we do for Autopep8Formatter.

Fixes #67 