### PR TITLE
Support more options from styler

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -161,8 +161,24 @@ class StylerFormatter(BaseFormatter):
         import rpy2.robjects.packages as rpackages
 
         styler_r = rpackages.importr(self.package_name)
-        formatted_code = styler_r.style_text(code, **options)
+        formatted_code = styler_r.style_text(code, **self._transform_options(options))
         return "\n".join(formatted_code)
+
+    @staticmethod
+    def _transform_options(options):
+        transformed_options = copy.deepcopy(options)
+
+        if "math_token_spacing" in transformed_options:
+            transformed_options["math_token_spacing"] = rpy2.robjects.ListVector(
+                transformed_options["math_token_spacing"]
+            )
+
+        if "reindention" in transformed_options:
+            transformed_options["reindention"] = rpy2.robjects.ListVector(
+                transformed_options["reindention"]
+            )
+
+        return transformed_options
 
 
 SERVER_FORMATTERS = {

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -196,10 +196,16 @@
         "styler": {
             "properties": {
                 "scope": {
-                    "type": "boolean"
+                    "type": "string"
                 },
                 "strict": {
                     "type": "boolean"
+                },
+                "math_token_spacing": {
+                    "type": "object"
+                },
+                "reindention": {
+                    "type": "object"
                 }
             },
             "additionalProperties": false,


### PR DESCRIPTION
Reference used: https://www.tidyverse.org/articles/2017/12/styler-1.0.0/

- `scope` option is a string, fix schema;
- Support `math_token_spacing` by transforming to R list, add to schema;
- Support `reindention` by transforming to R list, add to schema;

Fixes: #63 