### PR TITLE
labextension: Stop logging error into console and use `showErrorMessage`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Jupyterlab extension
 --------------------
 
 * Fully prohibit mismatched lab and server extension usage (accounting for either stale lab or server extension);
+* Use Jupyterlab dialogs for error reporting instead of console for clarity;
 
 1.2.0 2020-03-04
 ================

--- a/labextension/src/formatter.ts
+++ b/labextension/src/formatter.ts
@@ -4,6 +4,7 @@ import { ServerConnection } from '@jupyterlab/services';
 import JupyterlabCodeFormatterClient from './client';
 import { IEditorTracker } from '@jupyterlab/fileeditor';
 import { Widget } from '@lumino/widgets';
+import { showErrorMessage } from '@jupyterlab/apputils';
 
 class JupyterlabCodeFormatter {
   protected client: JupyterlabCodeFormatterClient;
@@ -128,21 +129,20 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
               ? formattedText.code.slice(0, -1)
               : formattedText.code;
           } else {
-            console.error(
-              'Could not format cell: %s due to:\n%o',
-              currentText,
+            await showErrorMessage(
+              'Jupyterlab Code Formatter Error',
               formattedText.error
             );
           }
         } else {
-          console.error(
-            'Value changed since we formatted - skipping: %s',
-            cell.model.value.text
+          await showErrorMessage(
+            'Jupyterlab Code Formatter Error',
+            `Cell value changed since format request was sent, formatting for cell ${i} skipped.`
           );
         }
       }
-    } catch (err) {
-      console.error('Something went wrong :(\n%o', err);
+    } catch (error) {
+      await showErrorMessage('Jupyterlab Code Formatter Error', error);
     }
     this.working = false;
   }
@@ -182,9 +182,9 @@ export class JupyterlabFileEditorCodeFormatter extends JupyterlabCodeFormatter {
           data.code[0].code;
         this.working = false;
       })
-      .catch(err => {
+      .catch(error => {
         this.working = false;
-        console.error('Something went wrong :(:\n%o', err);
+        void showErrorMessage('Jupyterlab Code Formatter Error', error);
       });
   }
 

--- a/labextension/src/index.ts
+++ b/labextension/src/index.ts
@@ -151,7 +151,9 @@ class JupyterLabCodeFormatter
         settings.changed.connect(onSettingsUpdated);
         onSettingsUpdated(settings);
       })
-      .catch((reason: Error) => console.error(reason.message));
+      .catch((error: Error) => {
+        void showErrorMessage('Jupyterlab Code Formatter Error', error);
+      });
   }
 
   private setupCommand(name: string, label: string, command: string) {


### PR DESCRIPTION
`showErrorMessage` is much better because it actually inform the end
user in a much cleaner fashion - so use it for basically every error
reporting from now on.