### PR TITLE
labextension: Set isort and Black as default_formatter for Python

### DIFF
--- a/labextension/schema/settings.json
+++ b/labextension/schema/settings.json
@@ -231,7 +231,7 @@
             "$ref": "#/definitions/preferences",
             "default" : {
                 "default_formatter": {
-                    "python": "black",
+                    "python": ["isort", "black"],
                     "r": "formatR"
                 }
             }


### PR DESCRIPTION
Version 1.2.1 introduced the possibility to invoke more than one
formatter with a single command. Black does not optimize imports, so for
complete Python formatting it should be used together with isort, see:
https://github.com/psf/black/issues/333

This commit sets both isort and Black as default_formatter for Python.