### PR TITLE
labextension: Set isort configuration for Black compatibility

### DIFF
--- a/labextension/schema/settings.json
+++ b/labextension/schema/settings.json
@@ -263,7 +263,13 @@
             "title": "Isort Config",
             "description": "Config to be passed into isort's SortImports function call.",
             "$ref": "#/definitions/isort",
-            "default": {}
+            "default": {
+                "multi_line_output": 3,
+                "include_trailing_comma": true,
+                "force_grid_wrap": 0,
+                "use_parentheses": true,
+                "line_length": 88
+            }
         },
         "formatR": {
             "title": "FormatR Config",


### PR DESCRIPTION
The default isort formatting style is not compatible with Black. This
commit sets the isort configuration as per the following instructions:
https://github.com/psf/black/tree/991f19031cc66dbaa62384a6f7387a3db5c58335

Notice that isort 5.0 will include a built-in Black compatible profile,
so in future the isort configuration could be simplified.