### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,7 @@ With Conda
 
 .. code-block:: bash
 
-    conda install -c conda-forge black
+    conda install black nodejs
     jupyter labextension install @ryantam626/jupyterlab_code_formatter
     conda install -c conda-forge jupyterlab_code_formatter
     jupyter serverextension enable --py jupyterlab_code_formatter


### PR DESCRIPTION
The `black` formatter is no longer only on conda forge. Also the jupyter labextensions need `nodejs` and `npm`, which are not installed by default. Installing the `nodejs` package ensures the extension can be installed.