### PR TITLE
Use Code Mirror Language if Kernelspec Language is Empty

### DIFF
--- a/labextension/src/formatter.ts
+++ b/labextension/src/formatter.ts
@@ -77,11 +77,15 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
   }
 
   private getNotebookType() {
-    if (!this.notebookTracker.currentWidget) return null;
+    if (!this.notebookTracker.currentWidget) {
+      return null;
+    }
 
     const metadata = this.notebookTracker.currentWidget.content.model.metadata.toJSON();
 
-    if (!metadata) return null;
+    if (!metadata) {
+      return null;
+    }
 
     // prefer kernelspec language
     // @ts-ignore

--- a/labextension/src/formatter.ts
+++ b/labextension/src/formatter.ts
@@ -77,17 +77,24 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
   }
 
   private getNotebookType() {
-    if (this.notebookTracker.currentWidget) {
-      const metadata = this.notebookTracker.currentWidget.content.model.metadata.toJSON();
-      if (metadata && metadata.kernelspec) {
-        // @ts-ignore
-        return metadata.kernelspec.language;
-      }
-      if (metadata && metadata.language_info) {
-        // @ts-ignore
-        return metadata.language_info.codemirror_mode.name;
-      }
+    if (!this.notebookTracker.currentWidget) return null;
+
+    const metadata = this.notebookTracker.currentWidget.content.model.metadata.toJSON();
+
+    if (!metadata) return null;
+
+    // prefer kernelspec language
+    if (metadata.kernelspec && metadata.kernelspec.language) {
+      // @ts-ignore
+      return metadata.kernelspec.language;
     }
+
+    // otherwise, check language info code mirror mode
+    if (metadata.language_info && metadata.language_info.codemirror_mode) {
+      // @ts-ignore
+      return metadata.language_info.codemirror_mode.name;
+    }
+
     return null;
   }
 

--- a/labextension/src/formatter.ts
+++ b/labextension/src/formatter.ts
@@ -84,12 +84,14 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
     if (!metadata) return null;
 
     // prefer kernelspec language
+    // @ts-ignore
     if (metadata.kernelspec && metadata.kernelspec.language) {
       // @ts-ignore
       return metadata.kernelspec.language;
     }
 
     // otherwise, check language info code mirror mode
+    // @ts-ignore
     if (metadata.language_info && metadata.language_info.codemirror_mode) {
       // @ts-ignore
       return metadata.language_info.codemirror_mode.name;


### PR DESCRIPTION
Closes https://github.com/ryantam626/jupyterlab_code_formatter/issues/131

@ryantam626 Let me know if you need me to make changes.

As per the discussion in #131 the following code does not have the intended behavior

```js
  private getNotebookType() {
    if (this.notebookTracker.currentWidget) {
      const metadata = this.notebookTracker.currentWidget.content.model.metadata.toJSON();
     // 1. Both metadata and metadata.kernelspec are defined
      if (metadata && metadata.kernelspec) {
        // 2. It returns metadata.kernelspec.language, which is ""
        // @ts-ignore
        return metadata.kernelspec.language;
      }
     // We never get here :( 
      if (metadata && metadata.language_info) {
        // @ts-ignore
        return metadata.language_info.codemirror_mode.name;
      }
    }
    return null;
  }
```

This PR only returns `metadata.kernelspec.language` if it is non-empty. If it is empty and `metadata.language_info` is define it returns the `language_info.codemirror_mode.name` value  