### PR TITLE
serverextension/labextension: Move ending handling + fix semicolon logic

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,12 +7,14 @@ Unreleased
 Server extension
 ----------------
 
-No changes.
+* Move cell/file ending handling back to server extension;
+* Fix semicolon handling;
 
 Jupyterlab extension
 --------------------
 
-No changes.
+* Move cell/file ending handling back to server extension;
+* Fix erroneous detection of R default formatters;
 
 1.2.5 2020-04-25
 ================

--- a/labextension/src/formatter.ts
+++ b/labextension/src/formatter.ts
@@ -13,13 +13,19 @@ class JupyterlabCodeFormatter {
     this.client = client;
   }
 
-  protected formatCode(code: string[], formatter: string, options: any) {
+  protected formatCode(
+    code: string[],
+    formatter: string,
+    options: any,
+    notebook: boolean
+  ) {
     return this.client
       .request(
         'format',
         'POST',
         JSON.stringify({
           code,
+          notebook,
           formatter,
           options
         }),
@@ -150,7 +156,8 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
         const formattedTexts = await this.formatCode(
           currentTexts,
           formatterToUse,
-          config[formatterToUse]
+          config[formatterToUse],
+          true
         );
         for (let i = 0; i < selectedCells.length; ++i) {
           const cell = selectedCells[i];
@@ -163,9 +170,7 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
                 formattedText.error
               );
             } else {
-              cell.model.value.text = formattedText.code.endsWith('\n')
-                ? formattedText.code.slice(0, -1)
-                : formattedText.code;
+              cell.model.value.text = formattedText.code;
             }
           } else {
             await showErrorMessage(
@@ -207,7 +212,7 @@ export class JupyterlabFileEditorCodeFormatter extends JupyterlabCodeFormatter {
     this.working = true;
     const editor = editorWidget.content.editor;
     const code = editor.model.value.text;
-    this.formatCode([code], formatter, config[formatter])
+    this.formatCode([code], formatter, config[formatter], false)
       .then(data => {
         if (data.code[0].error) {
           void showErrorMessage(

--- a/serverextension/jupyterlab_code_formatter/handlers.py
+++ b/serverextension/jupyterlab_code_formatter/handlers.py
@@ -93,12 +93,17 @@ class FormatAPIHandler(APIHandler):
                 self.set_status(404, "Formatter not found!")
                 self.finish()
             else:
+                notebook = data["notebook"]
                 options = data["options"] or {}
                 formatted_code = []
                 for code in data["code"]:
                     try:
                         formatted_code.append(
-                            {"code": formatter_instance.format_code(code, **options)}
+                            {
+                                "code": formatter_instance.format_code(
+                                    code, notebook, **options
+                                )
+                            }
                         )
                     except Exception as e:
                         formatted_code.append({"error": str(e)})

--- a/serverextension/jupyterlab_code_formatter/tests/test_handlers.py
+++ b/serverextension/jupyterlab_code_formatter/tests/test_handlers.py
@@ -82,7 +82,12 @@ class TestHandlers(NotebookTestBase):
             verb="POST",
             path="/jupyterlab_code_formatter/format",
             data=json.dumps(
-                {"code": code, "options": options, "formatter": formatter,}
+                {
+                    "code": code,
+                    "options": options,
+                    "notebook": True,
+                    "formatter": formatter,
+                }
             ),
             headers=self._create_headers(plugin_version),
         )
@@ -118,12 +123,12 @@ class TestHandlers(NotebookTestBase):
             options={"line_length": 88},
         )
         json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == "x = 22\ne = 1\n"
+        assert json_result["code"][0]["code"] == "x = 22\ne = 1"
 
     def test_can_use_black_config(self):
         """Check that it can apply black with advanced config."""
         given = "some_string='abc'"
-        expected = "some_string = 'abc'\n"
+        expected = "some_string = 'abc'"
 
         response = self._format_code_request(
             formatter="black",
@@ -149,7 +154,7 @@ class TestHandlers(NotebookTestBase):
     def test_can_handle_magic(self):
         """Check that it's fine to run formatters for code with magic."""
         given = '%%timeit\nsome_string = "abc"'
-        expected = '%%timeit\nsome_string = "abc"\n'
+        expected = '%%timeit\nsome_string = "abc"'
         for formatter in ["black", "yapf", "isort"]:
             response = self._format_code_request(
                 formatter=formatter, code=[given], options={},


### PR DESCRIPTION
Move trailing new line removal back to labextension (after introducing
additional field of `notebook` to inform whether formatting request is
made for a notebook cell or a file).

Fix semicolon handling logic, this currently introduce broken code after
formatting with semicolon.