### PR TITLE
Support isort 5 (without droping isort 4 support)

### DIFF
--- a/serverextension/jupyterlab_code_formatter/formatters.py
+++ b/serverextension/jupyterlab_code_formatter/formatters.py
@@ -137,9 +137,14 @@ class IsortFormatter(BaseFormatter):
 
     @handle_line_ending_and_magic
     def format_code(self, code: str, notebook: bool, **options) -> str:
-        from isort import SortImports
+        try:
+            from isort import SortImports
 
-        return SortImports(file_contents=code, **options).output
+            return SortImports(file_contents=code, **options).output
+        except ImportError:
+            import isort
+
+            return isort.code(code=code, **options)
 
 
 class FormatRFormatter(BaseFormatter):


### PR DESCRIPTION
Isort 5 was released a few days ago introducing some breaking changes.

Maybe is too soon for the extension to support the new API only, so I propose this to support both versions, al least for now.