### PR TITLE
Auto format code when save the notebook

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -226,6 +226,10 @@
             },
             "additionalProperties": false,
             "type": "object"
+        },
+        "formatOnSave": {
+            "additionalProperties": false,
+            "type": "boolean"
         }
     },
     "properties": {
@@ -291,6 +295,12 @@
             "description": "Config to be passed into styler's style_text function call.",
             "$ref": "#/definitions/styler",
             "default": {}
+        },
+        "formatOnSave": {
+            "title": "Auto format config",
+            "description": "Auto format code when save the notebook.",
+            "$ref": "#/definitions/formatOnSave",
+            "default": false
         }
     },
     "additionalProperties": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,9 +96,19 @@ class JupyterLabCodeFormatter
       this.app.commands.label(Constants.FORMAT_ALL_COMMAND),
       button
     );
+
+    context.saveState.connect(this.onSave, this);
+
     return new DisposableDelegate(() => {
       button.dispose();
     });
+  }
+
+  private async onSave(context: DocumentRegistry.IContext<INotebookModel>, state: DocumentRegistry.SaveState) {
+    // Before save
+    if (state == 'started') {
+      await this.notebookCodeFormatter.formatAllCodeCells(this.config);
+    }
   }
 
   private setupWidgetExtension() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,8 +105,7 @@ class JupyterLabCodeFormatter
   }
 
   private async onSave(context: DocumentRegistry.IContext<INotebookModel>, state: DocumentRegistry.SaveState) {
-    // Before save
-    if (state == 'started') {
+    if (state == 'started' && this.config.formatOnSave) {
       await this.notebookCodeFormatter.formatAllCodeCells(this.config);
     }
   }


### PR DESCRIPTION
related:#14

### WHAT

- Add settings `formatOnSave` (boolean, deafult=false)
    - if `formatOnSave == true` then, Auto format code when save the notebook
    - if `formatOnSave == false` then, Does not work auto format (Same as before)  

### References

I make this PR based on these, thanks. 
- https://github.com/ryantam626/jupyterlab_code_formatter/issues/14#issuecomment-539459331
- https://github.com/wallneradam/jupyterlab-trailing-space-remover

-----

I'm not native English & TypeScript.
So, if anyone have any good idea or requests, please review & discuss.

thanks this extension :)