### PR TITLE
Added include_trailing_comma to black

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -30,6 +30,9 @@
         },
         "black": {
             "properties": {
+                "include_trailing_comma": {
+                    "type": "boolean"
+                },
                 "line_length": {
                     "type": "number"
                 },

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -252,6 +252,7 @@
             "description": "Config to be passed into black's format_str function call.",
             "$ref": "#/definitions/black",
             "default": {
+                "include_trailing_comma": true,
                 "line_length": 88,
                 "string_normalization": true
             }


### PR DESCRIPTION
One of black's configuration options is [include_trailing_comma](https://black.readthedocs.io/en/stable/compatible_configs.html#configuration) which I'd like to be able to set