### PR TITLE
Add profile and ensure_newline_before_comments arguments to isort

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -42,6 +42,12 @@
         },
         "isort": {
             "properties": {
+                "profile": {
+                    "type": "string"
+                },
+                "ensure_newline_before_comments": {
+                    "type": "boolean"
+                },
                 "force_to_top": {
                     "type": "string"
                 },


### PR DESCRIPTION
Noticed I was getting some validation errors:

```txt
Additional properties are not allowed ('profile', 'ensure_newline_before_comments' were unexpected)
```

Both are [valid isort configuration options](https://pycqa.github.io/isort/docs/configuration/options.html#ensure-newline-before-comments), so I've added them in `settings.json`.

Closes #217