### PR TITLE
Update error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,8 +217,9 @@ class JupyterLabCodeFormatter
       .catch(error => {
         void showErrorMessage(
           'Jupyterlab Code Formatter Error',
-          'Unable to find server plugin version, this should be impossible,' +
-            'open a GitHub issue if you cannot figure this issue out yourself.'
+          'Unable to find server plugin version. You may need to restart your JupyterLab server, '+
+          'If that does not fix the issue please open an issue at: ' +
+          'https://github.com/ryantam626/jupyterlab_code_formatter/issues/new/choose'
         );
         return false;
       });


### PR DESCRIPTION
Turns out it is possible! If you have jupyterlab open, install this extension from a different terminal, and then refresh the page you will get this message.

As I managed here:
![image](https://user-images.githubusercontent.com/10111092/169182520-2ddbc3f0-179c-4403-b413-69f010ea3d3e.png)
