### PR TITLE
Remove notebook package dependency and improve importable implementation

### DIFF
--- a/dev/requirements.in
+++ b/dev/requirements.in
@@ -3,6 +3,7 @@ black
 blue
 isort
 pytest
+pytest-tornasync
 sphinx
 furo
 twine

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -6,31 +6,29 @@
 #
 alabaster==0.7.12
     # via sphinx
-appdirs==1.4.4
-    # via black
 attrs==21.4.0
     # via pytest
 autopep8==1.6.0
     # via -r /app/requirements.in
-babel==2.9.1
+babel==2.10.3
     # via sphinx
 beautifulsoup4==4.11.1
     # via furo
-black==21.7b0
+black==22.1.0
     # via
     #   -r /app/requirements.in
     #   blue
-bleach==5.0.0
+bleach==5.0.1
     # via readme-renderer
-blue==0.8.0
+blue==0.9.0
     # via -r /app/requirements.in
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   cryptography
     #   rpy2
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.0.2
     # via
@@ -38,24 +36,24 @@ click==8.0.2
     #   black
 commonmark==0.9.1
     # via rich
-cryptography==36.0.2
+cryptography==37.0.2
     # via secretstorage
 deprecation==2.1.0
     # via jupyter-packaging
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   myst-parser
     #   readme-renderer
     #   sphinx
 flake8==4.0.1
     # via blue
-furo==2022.4.7
+furo==2022.6.21
     # via -r /app/requirements.in
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via
     #   keyring
     #   sphinx
@@ -68,14 +66,14 @@ jeepney==0.8.0
     # via
     #   keyring
     #   secretstorage
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   myst-parser
     #   rpy2
     #   sphinx
-jupyter-packaging==0.12.0
+jupyter-packaging==0.12.2
     # via -r /app/requirements.in
-keyring==23.5.0
+keyring==23.6.0
     # via twine
 markdown-it-py==2.1.0
     # via
@@ -91,7 +89,7 @@ mdurl==0.1.1
     # via markdown-it-py
 mypy-extensions==0.4.3
     # via black
-myst-parser==0.17.2
+myst-parser==0.18.0
     # via -r /app/requirements.in
 packaging==21.3
     # via
@@ -101,8 +99,10 @@ packaging==21.3
     #   sphinx
 pathspec==0.9.0
     # via black
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
+platformdirs==2.5.2
+    # via black
 pluggy==1.0.0
     # via pytest
 py==1.11.0
@@ -115,15 +115,19 @@ pycparser==2.21
     # via cffi
 pyflakes==2.4.0
     # via flake8
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   furo
     #   readme-renderer
     #   rich
     #   sphinx
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
-pytest==7.1.1
+pytest==7.1.2
+    # via
+    #   -r /app/requirements.in
+    #   pytest-tornasync
+pytest-tornasync==0.6.0.post2
     # via -r /app/requirements.in
 pytz==2022.1
     # via
@@ -135,9 +139,7 @@ pyyaml==6.0
     # via myst-parser
 readme-renderer==35.0
     # via twine
-regex==2022.3.15
-    # via black
-requests==2.27.1
+requests==2.28.1
     # via
     #   requests-toolbelt
     #   sphinx
@@ -146,9 +148,9 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==12.2.0
+rich==12.4.4
     # via twine
-rpy2==3.5.1
+rpy2==3.5.2
     # via -r /app/requirements.in
 secretstorage==3.3.2
     # via keyring
@@ -158,13 +160,16 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.3.2.post1
     # via beautifulsoup4
-sphinx==4.5.0
+sphinx==5.0.2
     # via
     #   -r /app/requirements.in
     #   furo
     #   myst-parser
+    #   sphinx-basic-ng
     #   sphinx-copybutton
     #   sphinx-inline-tabs
+sphinx-basic-ng==0.0.1a12
+    # via furo
 sphinx-copybutton==0.5.0
     # via -r /app/requirements.in
 sphinx-inline-tabs==2022.1.2b11
@@ -183,16 +188,20 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 toml==0.10.2
     # via autopep8
-tomli==1.2.3
+tomli==2.0.1
     # via
     #   black
     #   pytest
-tomlkit==0.10.1
+tomlkit==0.11.0
     # via jupyter-packaging
-twine==4.0.0
+tornado==6.2
+    # via pytest-tornasync
+twine==4.0.1
     # via -r /app/requirements.in
-typing-extensions==4.2.0
-    # via myst-parser
+typing-extensions==4.3.0
+    # via
+    #   black
+    #   myst-parser
 tzdata==2022.1
     # via pytz-deprecation-shim
 tzlocal==4.2

--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -1,11 +1,13 @@
 import abc
 import copy
+import importlib
 import logging
 import re
 import sys
-import importlib
 from functools import wraps
 from typing import List, Type
+
+import pkg_resources
 
 try:
     import rpy2
@@ -13,7 +15,6 @@ try:
 except ImportError:
     pass
 from packaging import version
-
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +208,13 @@ def handle_line_ending_and_magic(func):
 BLUE_MONKEY_PATCHED = False
 
 
+def is_importable(pkg_name: str) -> bool:
+    # Need to reload for packages are installed/uninstalled after JupyterLab started
+    importlib.reload(pkg_resources)
+
+    return pkg_name in {pkg.key for pkg in pkg_resources.working_set}
+
+
 def import_black():
     global BLUE_MONKEY_PATCHED
     if BLUE_MONKEY_PATCHED:
@@ -242,12 +250,7 @@ class BlueFormatter(BaseFormatter):
 
     @property
     def importable(self) -> bool:
-        try:
-            import_blue()
-
-            return True
-        except ImportError:
-            return False
+        return is_importable('blue')
 
     @staticmethod
     def handle_options(**options):
@@ -269,12 +272,7 @@ class BlackFormatter(BaseFormatter):
 
     @property
     def importable(self) -> bool:
-        try:
-            import_black()
-
-            return True
-        except ImportError:
-            return False
+        return is_importable('black')
 
     @staticmethod
     def handle_options(**options):
@@ -301,12 +299,7 @@ class Autopep8Formatter(BaseFormatter):
 
     @property
     def importable(self) -> bool:
-        try:
-            import autopep8
-
-            return True
-        except ImportError:
-            return False
+        return is_importable('autopep8')
 
     @handle_line_ending_and_magic
     def format_code(self, code: str, notebook: bool, **options) -> str:
@@ -321,12 +314,7 @@ class YapfFormatter(BaseFormatter):
 
     @property
     def importable(self) -> bool:
-        try:
-            import yapf
-
-            return True
-        except ImportError:
-            return False
+        return is_importable('yapf')
 
     @handle_line_ending_and_magic
     def format_code(self, code: str, notebook: bool, **options) -> str:
@@ -341,12 +329,7 @@ class IsortFormatter(BaseFormatter):
 
     @property
     def importable(self) -> bool:
-        try:
-            import isort
-
-            return True
-        except ImportError:
-            return False
+        return is_importable('isort')
 
     @handle_line_ending_and_magic
     def format_code(self, code: str, notebook: bool, **options) -> str:

--- a/jupyterlab_code_formatter/handlers.py
+++ b/jupyterlab_code_formatter/handlers.py
@@ -1,16 +1,14 @@
 import json
 
-from jupyter_server.base.handlers import APIHandler
-from jupyter_server.utils import url_path_join
-
 import pkg_resources
-
-from notebook.notebookapp import NotebookWebApplication
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.serverapp import ServerWebApplication
+from jupyter_server.utils import url_path_join
 
 from .formatters import SERVER_FORMATTERS
 
 
-def setup_handlers(web_app: NotebookWebApplication) -> None:
+def setup_handlers(web_app: ServerWebApplication) -> None:
     host_pattern = ".*$"
     web_app.add_handlers(
         host_pattern,

--- a/jupyterlab_code_formatter/tests/conftest.py
+++ b/jupyterlab_code_formatter/tests/conftest.py
@@ -1,0 +1,78 @@
+import json
+import typing as t
+
+import pytest
+from jupyter_server.serverapp import ServerApp
+from tornado.httpclient import HTTPResponse
+
+from jupyterlab_code_formatter import load_jupyter_server_extension
+
+pytest_plugins = ["jupyter_server.pytest_plugin"]
+
+
+@pytest.fixture(autouse=True)
+def jcf_serverapp(jp_serverapp: ServerApp) -> ServerApp:
+    load_jupyter_server_extension(jp_serverapp)
+    return jp_serverapp
+
+
+@pytest.fixture
+def request_format(jp_fetch):  # type: ignore[no-untyped-def]
+    def do_request(
+        formatter: str,
+        code: t.List[str],
+        options: t.Dict[str, t.Any],
+        headers: t.Optional[t.Dict[str, t.Any]] = None,
+        **kwargs: t.Any,
+    ) -> HTTPResponse:
+        return jp_fetch(  # type: ignore[no-any-return]
+            "jupyterlab_code_formatter",
+            "format",
+            method="POST",
+            body=json.dumps(
+                {
+                    "code": code,
+                    "options": options,
+                    "notebook": True,
+                    "formatter": formatter,
+                }
+            ),
+            headers=headers,
+            **kwargs,
+        )
+
+    return do_request
+
+
+@pytest.fixture
+def request_list_formatters(jp_fetch):  # type: ignore[no-untyped-def]
+    def do_request(
+        headers: t.Optional[t.Dict[str, t.Any]] = None,
+        **kwargs: t.Any,
+    ) -> HTTPResponse:
+        return jp_fetch(  # type: ignore[no-any-return]
+            "jupyterlab_code_formatter",
+            "formatters",
+            method="GET",
+            headers=headers,
+            **kwargs,
+        )
+
+    return do_request
+
+
+@pytest.fixture
+def request_version(jp_fetch):  # type: ignore[no-untyped-def]
+    def do_request(
+        headers: t.Optional[t.Dict[str, t.Any]] = None,
+        **kwargs: t.Any,
+    ) -> HTTPResponse:
+        return jp_fetch(  # type: ignore[no-any-return]
+            "jupyterlab_code_formatter",
+            "version",
+            method="GET",
+            headers=headers,
+            **kwargs,
+        )
+
+    return do_request

--- a/jupyterlab_code_formatter/tests/test_handlers.py
+++ b/jupyterlab_code_formatter/tests/test_handlers.py
@@ -3,11 +3,10 @@ import typing as t
 
 import pkg_resources
 import pytest
-import requests
 from jsonschema import validate
+from tornado.httpclient import HTTPResponse
+
 from jupyterlab_code_formatter.formatters import SERVER_FORMATTERS
-from jupyterlab_code_formatter.handlers import setup_handlers
-from notebook.tests.launchnotebook import NotebookTestBase
 
 
 def _generate_list_formaters_entry_json_schema(
@@ -76,383 +75,503 @@ EXPECTED_FROMAT_SCHEMA = {
 SIMPLE_VALID_PYTHON_CODE = "x= 22;  e          =1"
 
 
-class TestHandlers(NotebookTestBase):
-    def setUp(self) -> None:
-        setup_handlers(self.notebook.web_app)
+def _create_headers(plugin_version: t.Optional[str] = None) -> t.Dict[str, str]:
+    return {
+        "Plugin-Version": plugin_version
+        if plugin_version is not None
+        else pkg_resources.get_distribution("jupyterlab_code_formatter").version
+    }
 
-    def _create_headers(
-        self, plugin_version: t.Optional[str] = None
-    ) -> t.Dict[str, str]:
-        return {
-            "Plugin-Version": plugin_version
-            if plugin_version is not None
-            else pkg_resources.get_distribution("jupyterlab_code_formatter").version
-        }
 
-    def _format_code_request(
-        self,
-        formatter: str,
-        code: t.List[str],
-        options: t.Dict[str, t.Any],
-        plugin_version: t.Optional[str] = None,
-    ) -> requests.Response:
-        return self.request(
-            verb="POST",
-            path="/jupyterlab_code_formatter/format",
-            data=json.dumps(
-                {
-                    "code": code,
-                    "options": options,
-                    "notebook": True,
-                    "formatter": formatter,
-                }
-            ),
-            headers=self._create_headers(plugin_version),
-        )
+def _check_http_code_and_schema(
+    response: HTTPResponse, expected_code: int, expected_schema: t.Dict[str, t.Any]
+) -> t.Dict[str, t.Any]:
+    assert response.code == expected_code
+    json_result: t.Dict[str, t.Any] = json.loads(response.body)
+    validate(instance=json_result, schema=expected_schema)
+    return json_result
 
-    @staticmethod
-    def _check_http_200_and_schema(response):
-        assert response.status_code == 200
-        json_result = response.json()
-        validate(instance=json_result, schema=EXPECTED_FROMAT_SCHEMA)
-        return json_result
 
-    def test_list_formatters(self):
-        """Check if the formatters list route works."""
-        response = self.request(
-            verb="GET",
-            path="/jupyterlab_code_formatter/formatters",
-            headers=self._create_headers(),
-        )
-        validate(instance=response.json(), schema=EXPECTED_LIST_FORMATTERS_SCHEMA)
+async def test_list_formatters(request_list_formatters):  # type: ignore[no-untyped-def]
+    """Check if the formatters list route works."""
+    response: HTTPResponse = await request_list_formatters(headers=_create_headers())
+    _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_LIST_FORMATTERS_SCHEMA,
+    )
 
-    def test_404_on_unknown(self):
-        """Check that it 404 correctly if formatter name is bad."""
-        response = self._format_code_request(
-            formatter="UNKNOWN", code=[SIMPLE_VALID_PYTHON_CODE], options={}
-        )
-        assert response.status_code == 404
 
-    def test_can_apply_python_formatter(self):
-        """Check that it can apply black with simple config."""
-        response = self._format_code_request(
-            formatter="black",
-            code=[SIMPLE_VALID_PYTHON_CODE],
-            options={"line_length": 88},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == "x = 22\ne = 1"
+async def test_404_on_unknown(request_format):  # type: ignore[no-untyped-def]
+    """Check that it 404 correctly if formatter name is bad."""
+    response: HTTPResponse = await request_format(
+        formatter="UNKNOWN",
+        code=[SIMPLE_VALID_PYTHON_CODE],
+        options={},
+        headers=_create_headers(),
+        raise_error=False,
+    )
+    assert response.code == 404
 
-    def test_can_use_black_config(self):
-        """Check that it can apply black with advanced config."""
-        given = "some_string='abc'"
-        expected = "some_string = 'abc'"
 
-        response = self._format_code_request(
-            formatter="black",
-            options={"line_length": 123, "string_normalization": False},
-            code=[given],
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
+async def test_can_apply_python_formatter(request_format):  # type: ignore[no-untyped-def]
+    """Check that it can apply black with simple config."""
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[SIMPLE_VALID_PYTHON_CODE],
+        options={"line_length": 88},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == "x = 22\ne = 1"
 
-    def test_return_error_if_any(self):
-        """Check that it returns the error if any."""
-        bad_python = "this_is_bad = 'hihi"
-        response = self._format_code_request(
-            formatter="black",
-            options={"line_length": 123, "string_normalization": False},
-            code=[bad_python],
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert (
-            json_result["code"][0]["error"] == "Cannot parse: 1:13: this_is_bad = 'hihi"
-        )
 
-    def test_can_handle_magic(self):
-        """Check that it's fine to run formatters for code with magic."""
-        given = '%%timeit\nsome_string = "abc"'
-        expected = '%%timeit\nsome_string = "abc"'
-        for formatter in ["black", "yapf", "isort"]:
-            response = self._format_code_request(
-                formatter=formatter,
-                code=[given],
-                options={},
-            )
-            json_result = self._check_http_200_and_schema(response)
-            assert json_result["code"][0]["code"] == expected
+async def test_can_use_black_config(request_format):  # type: ignore[no-untyped-def]
+    """Check that it can apply black with advanced config."""
+    given = "some_string='abc'"
+    expected = "some_string = 'abc'"
 
-    def test_can_handle_shell_cmd(self):
-        """Check that it's fine to run formatters for code with shell cmd."""
-        given = '%%timeit\nsome_string = "abc"\n!pwd'
-        expected = '%%timeit\nsome_string = "abc"\n!pwd'
-        for formatter in ["black", "yapf", "isort"]:
-            response = self._format_code_request(
-                formatter=formatter,
-                code=[given],
-                options={},
-            )
-            json_result = self._check_http_200_and_schema(response)
-            assert json_result["code"][0]["code"] == expected
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={"line_length": 123, "string_normalization": False},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
 
-    def test_can_handle_incompatible_magic_language(self):
-        """Check that it will ignore incompatible magic language cellblock."""
-        given = "%%html\n<h1>Hi</h1>"
-        expected = "%%html\n<h1>Hi</h1>"
-        for formatter in ["black", "yapf", "isort"]:
-            response = self._format_code_request(
-                formatter=formatter,
-                code=[given],
-                options={},
-            )
-            json_result = self._check_http_200_and_schema(response)
-            assert json_result["code"][0]["code"] == expected
 
-    def test_can_handle_incompatible_magic_language_single(self):
-        """Check that it will ignore incompatible magic language cellblock with single %."""
-        given = "%html <h1>Hi</h1>"
-        expected = "%html <h1>Hi</h1>"
-        for formatter in ["black", "yapf", "isort"]:
-            response = self._format_code_request(
-                formatter=formatter,
-                code=[given],
-                options={},
-            )
-            json_result = self._check_http_200_and_schema(response)
-            assert json_result["code"][0]["code"] == expected
+async def test_return_error_if_any(request_format):  # type: ignore[no-untyped-def]
+    """Check that it returns the error if any."""
+    bad_python = "this_is_bad = 'hihi"
 
-    def test_can_ipython_help_signle(self) -> None:
-        """Check that it will ignore single question mark interactive help lines on the fly."""
-        given = "    bruh?\nprint('test')\n#test?"
-        expected = '    bruh?\nprint("test")\n# test?'
-        response = self._format_code_request(
-            formatter="black",
-            code=[given],
-            options={},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[bad_python],
+        options={"line_length": 123, "string_normalization": False},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["error"] == "Cannot parse: 1:13: this_is_bad = 'hihi"
 
-    def test_can_ipython_help_double(self) -> None:
-        """Check that it will ignore double question mark interactive help lines on the fly."""
-        given = "    bruh??\nprint('test')\n#test?"
-        expected = '    bruh??\nprint("test")\n# test?'
-        response = self._format_code_request(
-            formatter="black",
-            code=[given],
-            options={},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
 
-    def test_will_ignore_quarto_comments(self) -> None:
-        """Check that it will ignore Quarto's comments at the top of a block."""
-        given = """#| eval: false
+@pytest.mark.parametrize("formatter", ("black", "yapf", "isort"))
+async def test_can_handle_magic(request_format, formatter):  # type: ignore[no-untyped-def]
+    """Check that it's fine to run formatters for code with magic."""
+    given = '%%timeit\nsome_string = "abc"'
+    expected = '%%timeit\nsome_string = "abc"'
+
+    response: HTTPResponse = await request_format(
+        formatter=formatter,
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+@pytest.mark.parametrize("formatter", ("black", "yapf", "isort"))
+async def test_can_handle_shell_cmd(request_format, formatter):  # type: ignore[no-untyped-def]
+    """Check that it's fine to run formatters for code with shell cmd."""
+    given = '%%timeit\nsome_string = "abc"\n!pwd'
+    expected = '%%timeit\nsome_string = "abc"\n!pwd'
+
+    response: HTTPResponse = await request_format(
+        formatter=formatter,
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+@pytest.mark.parametrize("formatter", ("black", "yapf", "isort"))
+async def test_can_handle_incompatible_magic_language(request_format, formatter):  # type: ignore[no-untyped-def]
+    """Check that it will ignore incompatible magic language cellblock."""
+    given = "%%html\n<h1>Hi</h1>"
+    expected = "%%html\n<h1>Hi</h1>"
+
+    response: HTTPResponse = await request_format(
+        formatter=formatter,
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+@pytest.mark.parametrize("formatter", ("black", "yapf", "isort"))
+async def test_can_handle_incompatible_magic_language_single(request_format, formatter):  # type: ignore[no-untyped-def]
+    """Check that it will ignore incompatible magic language cellblock with single %."""
+    given = "%html <h1>Hi</h1>"
+    expected = "%html <h1>Hi</h1>"
+
+    response: HTTPResponse = await request_format(
+        formatter=formatter,
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+async def test_can_ipython_help_signle(request_format):  # type: ignore[no-untyped-def]
+    """Check that it will ignore single question mark interactive help lines on the fly."""
+    given = "    bruh?\nprint('test')\n#test?"
+    expected = '    bruh?\nprint("test")\n# test?'
+
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+async def test_can_ipython_help_double(request_format):  # type: ignore[no-untyped-def]
+    """Check that it will ignore double question mark interactive help lines on the fly."""
+    given = "    bruh??\nprint('test')\n#test?"
+    expected = '    bruh??\nprint("test")\n# test?'
+
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+async def test_will_ignore_quarto_comments(request_format):  # type: ignore[no-untyped-def]
+    """Check that it will ignore Quarto's comments at the top of a block."""
+    given = """#| eval: false
 1 + 1"""
-        response = self._format_code_request(
-            formatter="black",
-            code=[given],
-            options={},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == given
 
-    def test_will_ignore_run_command(self) -> None:
-        """Check that it will ignore run command."""
-        given = "     run     some_script.py"
-        response = self._format_code_request(
-            formatter="black",
-            code=[given],
-            options={},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == given
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == given
 
-    def test_will_ignore_question_mark(self) -> None:
-        """Check that it will ignore single question mark in comments."""
-        given = """def f():
+
+async def test_will_ignore_run_command(request_format):  # type: ignore[no-untyped-def]
+    """Check that it will ignore run command."""
+    given = "     run     some_script.py"
+
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == given
+
+
+async def test_will_ignore_question_mark(request_format):  # type: ignore[no-untyped-def]
+    """Check that it will ignore single question mark in comments."""
+    given = """def f():
     # bruh what?
     # again bruh? really
     # a ? b
     print('hi')
     x = '?'"""
-        expected = """def f():
+    expected = """def f():
     # bruh what?
     # again bruh? really
     # a ? b
     print("hi")
     x = "?\""""
-        response = self._format_code_request(
-            formatter="black",
-            code=[given],
-            options={},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
 
-    def test_will_ignore_question_mark2(self) -> None:
-        """Check that it will ignore single question mark in comments."""
-        given = """def f():
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+async def test_will_ignore_question_mark2(request_format):  # type: ignore[no-untyped-def]
+    """Check that it will ignore double question mark in comments."""
+    given = """def f():
     # bruh what??
     # again bruh?? really
     # a ? b ? c
     print('hi')"""
-        expected = """def f():
+    expected = """def f():
     # bruh what??
     # again bruh?? really
     # a ? b ? c
     print("hi")"""
-        response = self._format_code_request(
-            formatter="black",
-            code=[given],
-            options={},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
 
-    def test_will_ignore_question_weird(self) -> None:
-        given = """wat
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+async def test_will_ignore_question_weird(request_format):  # type: ignore[no-untyped-def]
+    given = """wat
 wat??"""
-        expected = """wat
+    expected = """wat
 wat??"""
-        response = self._format_code_request(
-            formatter="black",
-            code=[given],
-            options={},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
 
-    def test_can_use_styler(self):
-        given = "a = 3; 2"
-        expected = "a <- 3\n2"
-        response = self._format_code_request(
-            formatter="styler",
-            code=[given],
-            options={"scope": "tokens"},
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
+    response: HTTPResponse = await request_format(
+        formatter="black",
+        code=[given],
+        options={},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
 
-    def test_can_use_styler_2(self):
-        given = """data_frame(
+
+async def test_can_use_styler(request_format):  # type: ignore[no-untyped-def]
+    given = "a = 3; 2"
+    expected = "a <- 3\n2"
+
+    response: HTTPResponse = await request_format(
+        formatter="styler",
+        code=[given],
+        options={"scope": "tokens"},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+async def test_can_use_styler2(request_format):  # type: ignore[no-untyped-def]
+    given = """data_frame(
      small  = 2 ,
      medium = 4,#comment without space
      large  =6
 )"""
-        expected = """data_frame(
+    expected = """data_frame(
   small  = 2,
   medium = 4, # comment without space
   large  = 6
 )"""
-        response = self._format_code_request(
-            code=[given],
-            options={"strict": False},
-            formatter="styler",
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
 
-    def test_can_use_styler_3(self):
-        given = "1++1/2*2^2"
-        expected = "1 + +1/2*2^2"
-        response = self._format_code_request(
-            formatter="styler",
-            options={
-                "math_token_spacing": {
-                    "one": ["'+'", "'-'"],
-                    "zero": ["'/'", "'*'", "'^'"],
-                }
-            },
-            code=[given],
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
+    response: HTTPResponse = await request_format(
+        formatter="styler",
+        code=[given],
+        options={"strict": False},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
 
-    def test_can_use_styler_4(self):
-        given = """a <- function() {
+
+async def test_can_use_styler3(request_format):  # type: ignore[no-untyped-def]
+    given = "1++1/2*2^2"
+    expected = "1 + +1/2*2^2"
+
+    response: HTTPResponse = await request_format(
+        formatter="styler",
+        code=[given],
+        options={
+            "math_token_spacing": {
+                "one": ["'+'", "'-'"],
+                "zero": ["'/'", "'*'", "'^'"],
+            }
+        },
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
+
+
+async def test_can_use_styler4(request_format):  # type: ignore[no-untyped-def]
+    given = """a <- function() {
     ### not to be indented
     # indent normally
     33
     }"""
-        expected = """a <- function() {
+    expected = """a <- function() {
 ### not to be indented
   # indent normally
   33
 }"""
 
-        response = self._format_code_request(
-            code=[given],
-            formatter="styler",
-            options=dict(
-                reindention=dict(regex_pattern="^###", indention=0, comments_only=True)
-            ),
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
+    response: HTTPResponse = await request_format(
+        formatter="styler",
+        code=[given],
+        options={
+            "reindention": {
+                "regex_pattern": "^###",
+                "indention": 0,
+                "comments_only": True,
+            }
+        },
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
 
-    def test_can_use_styler_5(self):
-        given = """call(
+
+async def test_can_use_styler5(request_format):  # type: ignore[no-untyped-def]
+    given = """call(
 #          SHOULD BE ONE SPACE BEFORE
 1,2)
 """
-        expected = """call(
+    expected = """call(
     # SHOULD BE ONE SPACE BEFORE
     1, 2
 )"""
-        response = self._format_code_request(
-            code=[given],
-            formatter="styler",
-            options=dict(indent_by=4, start_comments_with_one_space=True),
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
 
-    def test_can_use_styler_6(self):
-        given = "1+1-3"
-        expected = "1 + 1 - 3"
+    response: HTTPResponse = await request_format(
+        formatter="styler",
+        code=[given],
+        options={"indent_by": 4, "start_comments_with_one_space": True},
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
 
-        response = self._format_code_request(
-            code=[given],
-            formatter="styler",
-            options={
-                "math_token_spacing": "tidyverse_math_token_spacing",
-                "reindention": "tidyverse_reindention",
-            },
-        )
-        json_result = self._check_http_200_and_schema(response)
-        assert json_result["code"][0]["code"] == expected
 
-    def test_422_on_mismatch_version_1(self):
-        response = self.request(
-            verb="GET",
-            path="/jupyterlab_code_formatter/formatters",
-            headers=self._create_headers("0.0.0"),
-        )
-        assert response.status_code == 422
+async def test_can_use_styler6(request_format):  # type: ignore[no-untyped-def]
+    given = "1+1-3"
+    expected = "1 + 1 - 3"
 
-    def test_200_on_version_without_header(self):
-        response = self.request(
-            verb="GET",
-            path="/jupyterlab_code_formatter/version",
-        )
-        assert response.status_code == 200
-        validate(instance=response.json(), schema=EXPECTED_VERSION_SCHEMA)
+    response: HTTPResponse = await request_format(
+        formatter="styler",
+        code=[given],
+        options={
+            "math_token_spacing": "tidyverse_math_token_spacing",
+            "reindention": "tidyverse_reindention",
+        },
+        headers=_create_headers(),
+    )
+    json_result = _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_FROMAT_SCHEMA,
+    )
+    assert json_result["code"][0]["code"] == expected
 
-    def test_200_on_version_with_wrong_header(self):
-        response = self.request(
-            verb="GET",
-            path="/jupyterlab_code_formatter/version",
-            headers=self._create_headers("0.0.0"),
-        )
-        assert response.status_code == 200
-        validate(instance=response.json(), schema=EXPECTED_VERSION_SCHEMA)
 
-    def test_200_on_version_with_correct_header(self):
-        response = self.request(
-            verb="GET",
-            path="/jupyterlab_code_formatter/version",
-            headers=self._create_headers(),
-        )
-        assert response.status_code == 200
-        validate(instance=response.json(), schema=EXPECTED_VERSION_SCHEMA)
+async def test_422_on_mismatch_version_1(request_list_formatters):  # type: ignore[no-untyped-def]
+    response: HTTPResponse = await request_list_formatters(
+        headers=_create_headers("0.0.0"),
+        raise_error=False,
+    )
+    assert response.code == 422
+
+
+async def test_200_on_version_without_header(request_version):  # type: ignore[no-untyped-def]
+    response: HTTPResponse = await request_version()
+    _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_VERSION_SCHEMA,
+    )
+
+
+async def test_200_on_version_with_wrong_header(request_version):  # type: ignore[no-untyped-def]
+    response: HTTPResponse = await request_version(headers=_create_headers("0.0.0"))
+    _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_VERSION_SCHEMA,
+    )
+
+
+async def test_200_on_version_with_correct_header(request_version):  # type: ignore[no-untyped-def]
+    response: HTTPResponse = await request_version(headers=_create_headers())
+    _check_http_code_and_schema(
+        response=response,
+        expected_code=200,
+        expected_schema=EXPECTED_VERSION_SCHEMA,
+    )

--- a/jupyterlab_code_formatter/tests/test_handlers.py
+++ b/jupyterlab_code_formatter/tests/test_handlers.py
@@ -57,8 +57,16 @@ EXPECTED_FROMAT_SCHEMA = {
             "type": "array",
             "items": {
                 "type": "object",
-                "required": ["code"],
-                "properties": {"code": {"type": "string"}, "error": {"type": "string"}},
+                "oneOf": [
+                    {
+                        "additionalProperties": False,
+                        "properties": {"code": {"type": "string"}},
+                    },
+                    {
+                        "additionalProperties": False,
+                        "properties": {"error": {"type": "string"}},
+                    },
+                ],
             },
         }
     },

--- a/jupyterlab_code_formatter/tests/test_handlers.py
+++ b/jupyterlab_code_formatter/tests/test_handlers.py
@@ -15,9 +15,11 @@ def _generate_list_formaters_entry_json_schema(
 ) -> t.Dict[str, t.Any]:
     return {
         "type": "object",
+        "required": [formatter_name],
         "properties": {
             formatter_name: {
                 "type": "object",
+                "required": ["enabled", "label"],
                 "properties": {
                     "enabled": {"type": "boolean"},
                     "label": {"type": "string"},
@@ -29,6 +31,7 @@ def _generate_list_formaters_entry_json_schema(
 
 EXPECTED_VERSION_SCHEMA = {
     "type": "object",
+    "required": ["version"],
     "properties": {
         "version": {
             "type": "string",
@@ -38,6 +41,7 @@ EXPECTED_VERSION_SCHEMA = {
 
 EXPECTED_LIST_FORMATTERS_SCHEMA = {
     "type": "object",
+    "required": ["formatters"],
     "properties": {
         "formatters": {
             formatter_name: _generate_list_formaters_entry_json_schema(formatter_name)
@@ -47,11 +51,13 @@ EXPECTED_LIST_FORMATTERS_SCHEMA = {
 }
 EXPECTED_FROMAT_SCHEMA = {
     "type": "object",
+    "required": ["code"],
     "properties": {
         "code": {
             "type": "array",
             "items": {
                 "type": "object",
+                "required": ["code"],
                 "properties": {"code": {"type": "string"}, "error": {"type": "string"}},
             },
         }


### PR DESCRIPTION
closes #269, closes #270 

Summaries:

- Remove notebook package for fixing import error
- Improve importable implementation for fixing Internal Server Error when using blue formatter.
- Refactor Python unit tests
  - Also remove notebook package
  - Update json schema definition to validate correctly (Previously all fields are optional, so schema validation was not working)