### PR TITLE
Fix settings UI error with JupyterLab 3.3.0 or later

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -11,13 +11,13 @@
                         "python": {
                             "anyOf": [
                                 {"type": "string"},
-                                {"type": "array", "element":  "string"}
+                                {"type": "array", "items": {"type": "string"}}
                             ]
                         },
                         "R": {
                             "anyOf": [
                                 {"type": "string"},
-                                {"type": "array", "element":  "string"}
+                                {"type": "array", "items": {"type": "string"}}
                             ]
                         }
                     },
@@ -68,19 +68,19 @@
                 },
                 "known_future_library": {
                     "type": "array",
-                    "element": "string"
+                    "items": {"type": "string"}
                 },
                 "known_standard_library": {
                     "type": "array",
-                    "element": "string"
+                    "items": {"type": "string"}
                 },
                 "known_third_party": {
                     "type": "array",
-                    "element": "string"
+                    "items": {"type": "string"}
                 },
                 "known_first_party": {
                     "type": "array",
-                    "element": "string"
+                    "items": {"type": "string"}
                 },
                 "multi_line_output": {
                     "type": "number"
@@ -233,10 +233,47 @@
                     "type": "boolean"
                 },
                 "math_token_spacing": {
-                    "type": ["object", "string"]
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "zero": {
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {"type": "array", "items": {"type": "string"}}
+                                    ]
+                                },
+                                "one": {
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {"type": "array", "items": {"type": "string"}}
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "type": "object"
+                        },
+                        {"type": "string"}
+                    ]
                 },
                 "reindention": {
-                    "type": ["object", "string"]
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "regex_pattern": {
+                                    "type": "string"
+                                },
+                                "indention": {
+                                    "type": "number"
+                                },
+                                "comments_only": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "type": "object"
+                        },
+                        {"type": "string"}
+                    ]
                 }
             },
             "additionalProperties": false,
@@ -259,7 +296,7 @@
             "default" : {
                 "default_formatter": {
                     "python": ["isort", "black"],
-                    "r": "formatR"
+                    "R": "formatR"
                 }
             }
         },


### PR DESCRIPTION
Settings UI is GUI editor for extension settings introduced in JupyterLab 3.3.0 (https://github.com/jupyterlab/jupyterlab/pull/11079). This visual settings form is automatically generated by extension's schema with [rjsf](https://github.com/rjsf-team/react-jsonschema-form).
Currently some schema properties is non-compliant to json schema, so settings form show errors and We can not set these properties. This PR tries to resolve this.

<img width="794" alt="スクリーンショット 2022-07-08 15 14 49" src="https://user-images.githubusercontent.com/17161397/177931069-7e94f309-3568-4611-9196-03d88875ac57.png">

