### PR TITLE
Add a trailing new line

### DIFF
--- a/docs_src/changelog.md
+++ b/docs_src/changelog.md
@@ -10,6 +10,7 @@
 **Server extension**
 
 - Handle single/double leading question mark properly;
+- Re-add trailing new line if not in notebook;
 
 **Jupyterlab extension**
 

--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -198,6 +198,8 @@ def handle_line_ending_and_magic(func):
         code = func(self, code, notebook, **options)
 
         lines = code.splitlines()
+        lines.append("")
+
         for escaper in escapers:
             lines = map(escaper.unescape, lines)
         code = "\n".join(lines)


### PR DESCRIPTION
When I refactored by escape/unescape works, I accidentally removed a
trailing new line, re-add this, and to be trimmed if in notebook.

Related: #264 