### PR TITLE
Add isort config options for custom sections

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -378,14 +378,14 @@
             "$ref": "#/definitions/formatOnSave",
             "default": false
         },
-	"astyle":  {
-	    "title": "AStyle Config",
-            "description": "Command line options to be passed to astyle.",
-            "$ref": "#/definitions/astyle",
-            "default": {
-		"args": []
-	    }
-	},
+        "astyle":  {
+            "title": "AStyle Config",
+                "description": "Command line options to be passed to astyle.",
+                "$ref": "#/definitions/astyle",
+                "default": {
+            "args": []
+            }
+	    },
         "suppressFormatterErrors": {
             "title": "Suppress formatter errors",
             "description": "Whether to suppress all errors reported by formatter while formatting. Useful when you have format on save mode on.",

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -66,6 +66,10 @@
                 "wrap_length": {
                     "type": "number"
                 },
+                "sections": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                },
                 "known_future_library": {
                     "type": "array",
                     "items": {"type": "string"}

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -378,14 +378,14 @@
             "$ref": "#/definitions/formatOnSave",
             "default": false
         },
-        "astyle":  {
+        "astyle": {
             "title": "AStyle Config",
-                "description": "Command line options to be passed to astyle.",
-                "$ref": "#/definitions/astyle",
-                "default": {
-            "args": []
+            "description": "Command line options to be passed to astyle.",
+            "$ref": "#/definitions/astyle",
+            "default": {
+                "args": []
             }
-	    },
+        },
         "suppressFormatterErrors": {
             "title": "Suppress formatter errors",
             "description": "Whether to suppress all errors reported by formatter while formatting. Useful when you have format on save mode on.",

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -156,6 +156,12 @@
                     "type": "boolean"
                 }
             },
+            "patternProperties": {
+                "^known_[a-z_]+": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                }
+            },
             "additionalProperties": false,
             "type": "object"
         },

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -351,6 +351,7 @@
                 "include_trailing_comma": true,
                 "force_grid_wrap": 0,
                 "use_parentheses": true,
+                "ensure_newline_before_comments": true,
                 "line_length": 88
             }
         },


### PR DESCRIPTION
This PR is to add config options for the extension that allow for custom isort sections ([ref](https://pycqa.github.io/isort/docs/configuration/custom_sections_and_ordering.html)).

It also updates the isort default config to match the isort black profile, which seemed to be the intention ([ref](https://pycqa.github.io/isort/docs/configuration/profiles.html#black)).

Thanks for the great extension!