### PR TITLE
Use `importlib.utils.find_spec`, allow to cache results

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -9,14 +9,14 @@ import sys
 from functools import wraps
 from typing import List, Type
 
-import pkg_resources
-
 try:
     import rpy2
     import rpy2.robjects
 except ImportError:
     pass
 from packaging import version
+from functools import cache
+
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +58,11 @@ class BaseFormatter(abc.ABC):
     @abc.abstractmethod
     def format_code(self, code: str, notebook: bool, **options) -> str:
         pass
+
+    @property
+    @cache
+    def cached_importable(self) -> bool:
+        return self.importable
 
 
 class BaseLineEscaper(abc.ABC):
@@ -219,10 +224,8 @@ BLUE_MONKEY_PATCHED = False
 
 
 def is_importable(pkg_name: str) -> bool:
-    # Need to reload for packages are installed/uninstalled after JupyterLab started
-    importlib.reload(pkg_resources)
-
-    return pkg_name in {pkg.key for pkg in pkg_resources.working_set}
+    # find_spec will check for packages installed/uninstalled after JupyterLab started
+    return importlib.util.find_spec(pkg_name) is not None
 
 
 def command_exist(name: str) -> bool:

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -290,6 +290,9 @@
             "additionalProperties": false,
             "type": "boolean"
         },
+        "cacheFormatters": {
+            "type": "boolean"
+        },
         "suppressFormatterErrors": {
             "additionalProperties": false,
             "type":  "boolean"
@@ -365,6 +368,12 @@
             "title": "Auto format config",
             "description": "Auto format code when save the notebook.",
             "$ref": "#/definitions/formatOnSave",
+            "default": false
+        },
+        "cacheFormatters": {
+            "title": "Cache formatters",
+            "description": "Cache formatters on server for better performance (but will not detected newly installed/uninstalled formatters).",
+            "$ref": "#/definitions/cacheFormatters",
             "default": false
         },
 	"astyle":  {

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,8 +33,8 @@ class JupyterlabCodeFormatterClient {
     });
   }
 
-  public getAvailableFormatters() {
-    return this.request('formatters', 'GET', null);
+  public getAvailableFormatters(cache: boolean) {
+    return this.request('formatters' + (cache ? '?cached' : ''), 'GET', null);
   }
 
   public getVersion() {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -16,11 +16,12 @@ class JupyterlabCodeFormatter {
     code: string[],
     formatter: string,
     options: any,
-    notebook: boolean
+    notebook: boolean,
+    cache: boolean
   ) {
     return this.client
       .request(
-        'format',
+        'format' + (cache ? '?cached' : ''),
         'POST',
         JSON.stringify({
           code,
@@ -158,7 +159,8 @@ export class JupyterlabNotebookCodeFormatter extends JupyterlabCodeFormatter {
           currentTexts,
           formatterToUse,
           config[formatterToUse],
-          true
+          true,
+          config.cacheFormatters
         );
         for (let i = 0; i < selectedCells.length; ++i) {
           const cell = selectedCells[i];
@@ -217,7 +219,13 @@ export class JupyterlabFileEditorCodeFormatter extends JupyterlabCodeFormatter {
     this.working = true;
     const editor = editorWidget.content.editor;
     const code = editor.model.value.text;
-    this.formatCode([code], formatter, config[formatter], false)
+    this.formatCode(
+      [code],
+      formatter,
+      config[formatter],
+      false,
+      config.cacheFormatters
+    )
       .then(data => {
         if (data.code[0].error) {
           void showErrorMessage(


### PR DESCRIPTION
Fixes https://github.com/ryantam626/jupyterlab_code_formatter/issues/293

Switches to `importlib.util.find_spec` which is slightly faster than reloading packages.

Exposes a new user setting allowing to cache the formatter information:

![Screenshot from 2023-03-20 04-23-33](https://user-images.githubusercontent.com/5832902/226246645-9a258324-7465-43db-a2a2-57a506ab398e.png)
