### PR TITLE
Add support for formatting with ruff

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -474,6 +474,18 @@ class CommandLineFormatter(BaseFormatter):
             return process.stdout
 
 
+class RuffFixFormatter(CommandLineFormatter):
+
+    def __init__(self):
+        try:
+            from ruff.__main__ import find_ruff_bin
+
+            ruff_command = find_ruff_bin()
+        except (ImportError, FileNotFoundError):
+            ruff_command = "ruff"
+        self.command = [ruff_command, "check", "--fix-only", "-"]
+
+
 SERVER_FORMATTERS = {
     "black": BlackFormatter(),
     "blue": BlueFormatter(),
@@ -485,4 +497,5 @@ SERVER_FORMATTERS = {
     "scalafmt": CommandLineFormatter(command=["scalafmt", "--stdin"]),
     "rustfmt": CommandLineFormatter(command=["rustfmt"]),
     "astyle": CommandLineFormatter(command=["astyle"]),
+    "ruff": RuffFixFormatter(),
 }

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -296,6 +296,13 @@
             "additionalProperties": false,
             "type": "object"
         },
+        "ruff": {
+            "properties":{
+                "args": {"type": "array", "items": {"type": "string"}}
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
         "formatOnSave": {
             "additionalProperties": false,
             "type": "boolean"
@@ -393,6 +400,14 @@
             "$ref": "#/definitions/astyle",
             "default": {
                 "args": []
+            }
+        },
+        "ruff": {
+            "title": "Ruff Config",
+            "description": "Command line options to be passed to ruff.",
+            "$ref": "#/definitions/ruff",
+            "default": {
+                "args": ["--select=I"]
             }
         },
         "suppressFormatterErrors": {

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -407,7 +407,7 @@
             "description": "Command line options to be passed to ruff.",
             "$ref": "#/definitions/ruff",
             "default": {
-                "args": ["--select=I"]
+                "args": ["--select=I001"]
             }
         },
         "suppressFormatterErrors": {


### PR DESCRIPTION
This PR adds the custom ruff formatter I mentioned in issue #296.

I set a default argument to select `isort` rules only.
