### PR TITLE
fix: restore support for python>=3.7,<3.9

### DIFF
--- a/jupyterlab_code_formatter/formatters.py
+++ b/jupyterlab_code_formatter/formatters.py
@@ -14,7 +14,11 @@ try:
     import rpy2.robjects
 except ImportError:
     pass
-from functools import cache
+if sys.version_info >= (3, 9):
+    from functools import cache
+else:
+    from functools import lru_cache
+    cache = lru_cache(maxsize=None)
 
 from packaging import version
 

--- a/jupyterlab_code_formatter/tests/test_handlers.py
+++ b/jupyterlab_code_formatter/tests/test_handlers.py
@@ -1,6 +1,10 @@
 import json
+import sys
 import typing as t
-from importlib.metadata import version
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
 
 import pytest
 from jsonschema import validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
     "blue==0.9.1",
     "isort",
     "yapf",
+    "importlib_metadata; python_version<'3.8'",
 ]
 
 [tool.hatch.envs.default]


### PR DESCRIPTION
Fix https://github.com/ryantam626/jupyterlab_code_formatter/issues/309.

Tests pass for python 3.7-3.11 except `test_handlers.test_can_apply_ruff`, but the presence of the debugger suggests this might be expected. Is that right?